### PR TITLE
Removed usage of deprecated toString() method from the Symfony Config…

### DIFF
--- a/src/DICBuilder.php
+++ b/src/DICBuilder.php
@@ -66,7 +66,7 @@ class DICBuilder {
       return $container;
     }
 
-    require_once $cache;
+    require_once $cache->getPath();
 
     $container = new $class();
 


### PR DESCRIPTION
…Cache class.