### PR TITLE
Lock Symfony components on 2.6.* so the PHP version requirement does not go up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "This module provides the Dependency Injection Container integration in Drupal 7.",
     "type": "drupal-module",
     "require": {
-        "symfony/dependency-injection": "~2.4",
-        "symfony/config": "~2.4",
-        "symfony/yaml": "~2.4"
+        "symfony/dependency-injection": "2.6.*",
+        "symfony/config": "2.6.*",
+        "symfony/yaml": "2.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*"

--- a/src/DICBuilder.php
+++ b/src/DICBuilder.php
@@ -66,7 +66,7 @@ class DICBuilder {
       return $container;
     }
 
-    require_once $cache->getPath();
+    require_once $cache;
 
     $container = new $class();
 


### PR DESCRIPTION
Fixes #29 